### PR TITLE
implement freeVars function

### DIFF
--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -2,7 +2,7 @@ package com.github.symcal
 
 import scala.language.implicitConversions
 
-trait Expr {
+sealed trait Expr {
   def +(x: Expr): Expr = Add(this, x)
 
   def -(x: Expr): Expr = Subtract(this, x)
@@ -33,6 +33,8 @@ trait Expr {
   protected def toStringInternal: String
 
   override final def toString: String = stringForm(0)
+
+  def freeVars: Set[Var] = Expr.freeVars(this)
 }
 
 object Expr {
@@ -48,6 +50,16 @@ object Expr {
   final val precedenceOfMultiply = 50
   final val precedenceOfIntPow = 60
   final val precedenceOfConst = 100
+
+  def freeVars(e: Expr): Set[Var] = e match {
+    case Const(value) ⇒ Set()
+    case Subtract(x, y) ⇒ freeVars(x) ++ freeVars(y)
+    case Minus(x) ⇒ freeVars(x)
+    case Add(x, y) ⇒ freeVars(x) ++ freeVars(y)
+    case Multiply(x, y) ⇒ freeVars(x) ++ freeVars(y)
+    case Var(name) ⇒ Set(Var(name))
+    case IntPow(x, d) ⇒ freeVars(x)
+  }
 }
 
 case class Const(value: Int) extends Expr {

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -166,4 +166,21 @@ class ExprSpec extends FlatSpec with Matchers {
     q.subs('x, 2).toInt shouldEqual 20015
   }
 
+  behavior of "freeVars"
+
+  it should "compute empty set for an expression with no variables" in {
+    val x = Const(1)
+    Expr.freeVars(x) shouldEqual Set[Var]()
+  }
+
+  it should "compute a set of vars" in {
+    var x = Var('x)
+    var y = Var('y)
+
+    val p = x*y - 1
+    Expr.freeVars(p) shouldEqual Set(x, y)
+    val q = x #^ 2
+    q.freeVars shouldEqual Set(x)
+  }
+
 }


### PR DESCRIPTION
Compute the set of free variables in an expression. This will be useful for polynomials, functions, and so on.

For example, suppose we define

```scala
val z = Var('z)
val p = z*z - 1
```
and then we want to plot `p`. It will be useful to know that `p` depends on `z`.

Also, if we want to compile `p` as a native function, we need to know the name of the variables on which `p` depends.

Finally, we may want to implement symbolic function expressions such as `x -> x * x + a` and then it is important to know the set of free variables. Note that `x -> x*x +z` contains two variables: `x`, which is bound (not "free"), and `z`, which is free. It is useful to have a function that determines the set of free variables; for example, this will allow us to determine that `x -> x*x + z` cannot be computed numerically or plotted until `z` is given. This is why the name "free variables" is used.