### PR TITLE
Multi-term expressions

### DIFF
--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -231,7 +231,7 @@ final case class Sum(es: Expr*) extends Expr {
           // In this case, the simplified result is not a `Sum`.
           e
         } else Sum(mergedExprs: _*)
-      case None ⇒ Const(0) // Empty sequence is transformed into `Const(0)`.
+      case None ⇒ Const(0) // Empty sum is transformed into `Const(0)`.
     }
   }
 }
@@ -263,8 +263,8 @@ final case class Product(es: Expr*) extends Expr {
         if (mergedExprs.length == 1) {
           // In this case, the simplified result is not a `Sum`.
           e
-        } else Sum(mergedExprs: _*)
-      case None ⇒ Const(0) // Empty sequence is transformed into `Const(0)`.
+        } else Product(mergedExprs: _*)
+      case None ⇒ Const(1) // Empty product is transformed into `Const(1)`.
     }
   }
 }

--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -16,9 +16,11 @@ sealed trait Expr {
 
   def toInt: Int
 
-  def diff(x: Var): Expr
+  final def diff(x: Var): Expr = diffInternal(x).simplify
 
-  def simplify: Expr = this
+  private[symcal] def diffInternal(x: Var): Expr
+
+  def simplify: Expr
 
   def subs(v: Var, e: Expr): Expr
 
@@ -35,6 +37,8 @@ sealed trait Expr {
   override final def toString: String = stringForm(0)
 
   def freeVars: Set[Var] = Expr.freeVars(this)
+
+  def isConst: Boolean = false
 }
 
 object Expr {
@@ -59,25 +63,31 @@ object Expr {
     case Multiply(x, y) ⇒ freeVars(x) ++ freeVars(y)
     case Var(name) ⇒ Set(Var(name))
     case IntPow(x, d) ⇒ freeVars(x)
+    case Sum(es@_*) ⇒ es.flatMap(freeVars).toSet
+    case Product(es@_*) ⇒ es.flatMap(freeVars).toSet
   }
 }
 
-case class Const(value: Int) extends Expr {
+final case class Const(value: Int) extends Expr {
   override def toInt: Int = value
 
-  def diff(x: Var): Expr = Const(0)
+  private[symcal] def diffInternal(x: Var): Expr = Const(0)
 
   override def subs(v: Var, e: Expr): Expr = this
 
   override def precedenceLevel: Int = Expr.precedenceOfConst
 
   override def toStringInternal: String = value.toString
+
+  override def simplify: Expr = this
+
+  override def isConst: Boolean = true
 }
 
-case class Subtract(x: Expr, y: Expr) extends Expr {
+final case class Subtract(x: Expr, y: Expr) extends Expr {
   override def toInt: Int = x.toInt - y.toInt
 
-  override def diff(z: Var): Expr = (x.diff(z) - y.diff(z)).simplify
+  private[symcal] def diffInternal(z: Var): Expr = x.diff(z) - y.diff(z)
 
   override def subs(v: Var, e: Expr): Expr = (x.subs(v, e) - y.subs(v, e)).simplify
 
@@ -93,10 +103,10 @@ case class Subtract(x: Expr, y: Expr) extends Expr {
   override protected def toStringInternal: String = x.stringForm(Expr.precedenceOfAdd) + " - " + y.stringForm(Expr.precedenceOfMultiply)
 }
 
-case class Minus(x: Expr) extends Expr {
+final case class Minus(x: Expr) extends Expr {
   override def toInt: Int = -x.toInt
 
-  override def diff(z: Var): Expr = (-x.diff(z)).simplify
+  private[symcal] def diffInternal(z: Var): Expr = -x.diff(z)
 
   override def subs(v: Var, e: Expr): Expr = (-x.subs(v, e)).simplify
 
@@ -113,10 +123,10 @@ case class Minus(x: Expr) extends Expr {
 
 //case class FlatSum(xs: IndexedSeq[Expr])
 
-case class Add(x: Expr, y: Expr) extends Expr {
+final case class Add(x: Expr, y: Expr) extends Expr {
   override def toInt: Int = x.toInt + y.toInt
 
-  def diff(z: Var): Expr = (x.diff(z) + y.diff(z)).simplify
+  private[symcal] def diffInternal(z: Var): Expr = x.diff(z) + y.diff(z)
 
   override def simplify: Expr = (x.simplify, y.simplify) match {
     case (Const(0), ys) => ys
@@ -132,10 +142,10 @@ case class Add(x: Expr, y: Expr) extends Expr {
   override def precedenceLevel: Int = Expr.precedenceOfAdd
 }
 
-case class Multiply(x: Expr, y: Expr) extends Expr {
+final case class Multiply(x: Expr, y: Expr) extends Expr {
   override def toInt: Int = x.toInt * y.toInt
 
-  override def diff(z: Var): Expr = (Multiply(x.diff(z), y) + Multiply(x, y.diff(z))).simplify
+  private[symcal] def diffInternal(z: Var): Expr = Multiply(x.diff(z), y) + Multiply(x, y.diff(z))
 
   override def simplify: Expr = (x.simplify, y.simplify) match {
     case (Const(1), ys) => ys
@@ -153,11 +163,11 @@ case class Multiply(x: Expr, y: Expr) extends Expr {
   override def precedenceLevel: Int = Expr.precedenceOfMultiply
 }
 
-case class Var(name: Symbol) extends Expr {
+final case class Var(name: Symbol) extends Expr {
   override def toInt: Int =
     throw new Exception(s"Cannot evaluate toInt for an expression containing a variable ${name.name}.")
 
-  def diff(x: Var): Expr = if (name == x.name) Const(1) else Const(0)
+  private[symcal] def diffInternal(x: Var): Expr = if (name == x.name) Const(1) else Const(0)
 
   override def subs(v: Var, e: Expr): Expr = v match {
     case Var(`name`) ⇒ e
@@ -167,16 +177,18 @@ case class Var(name: Symbol) extends Expr {
   override def toStringInternal: String = name.name
 
   override def precedenceLevel: Int = Expr.precedenceOfConst
+
+  override def simplify: Expr = this
 }
 
-case class IntPow(x: Expr, d: Const) extends Expr {
+final case class IntPow(x: Expr, d: Const) extends Expr {
   override def toInt: Int = Math.pow(x.toInt, d.value).toInt
 
-  override def diff(z: Var): Expr = (d match {
+  private[symcal] def diffInternal(z: Var): Expr = d match {
     case Const(0) => Const(0)
-    case Const(1) => x.diff(z)
+    case Const(1) => x.diffInternal(z) // no need to `diff` here because `simplify` will follow
     case _ => d * x.diff(z) * IntPow(x, Const(d.value - 1))
-  }).simplify
+  }
 
   override def simplify: Expr = (x.simplify, d) match {
     case (Const(a), _) => Const(IntPow(Const(a), d).toInt)
@@ -190,4 +202,39 @@ case class IntPow(x: Expr, d: Const) extends Expr {
   override def toStringInternal: String = x.stringForm(precedenceLevel + 1) + "^" + d.toString
 
   override def precedenceLevel: Int = Expr.precedenceOfIntPow
+}
+
+final case class Sum(es: Expr*) extends Expr {
+  override def toInt: Int = ???
+
+  private[symcal] def diffInternal(x: Var): Expr = Sum(es.map(_.diff(x)): _*)
+
+  override def subs(v: Var, e: Expr): Expr = ???
+
+  override def precedenceLevel: Int = Expr.precedenceOfAdd
+
+  override protected def toStringInternal: String = es.map(_.stringForm(precedenceLevel)).mkString(" + ")
+
+  override def simplify: Expr = {
+    val (const, nonconst) = es.map(_.simplify).partition(_.isConst)
+    val mergedConstants = const.reduce((x, y) ⇒ (x + y).simplify)
+    mergedConstants match {
+      case Const(0) ⇒ Sum(nonconst: _*)
+      case _ ⇒ Sum(nonconst :+ mergedConstants: _*)
+    }
+  }
+}
+
+final case class Product(es: Expr*) extends Expr {
+  override def toInt: Int = ???
+
+  override def diffInternal(x: Var): Expr = ???
+
+  override def subs(v: Var, e: Expr): Expr = ???
+
+  override def precedenceLevel: Int = Expr.precedenceOfMultiply
+
+  override protected def toStringInternal: String = es.map(_.stringForm(precedenceLevel)).mkString(" * ")
+
+  override def simplify: Expr = ???
 }

--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -265,7 +265,7 @@ final case class Product(es: Expr*) extends Expr {
     mergedExprs.headOption match {
       case Some(e) ⇒
         if (mergedExprs.length == 1) {
-          // In this case, the simplified result is not a `Sum`.
+          // In this case, the simplified result is not a `Product`.
           e
         } else Product(mergedExprs: _*)
       case None ⇒ Const(1) // Empty product is transformed into `Const(1)`.

--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -239,7 +239,11 @@ final case class Sum(es: Expr*) extends Expr {
 final case class Product(es: Expr*) extends Expr {
   override def toInt: Int = es.map(_.toInt).product
 
-  override def diffInternal(x: Var): Expr = ???
+  override def diffInternal(x: Var): Expr = {
+    val diffs = es.map(_.diff(x))
+    val replaced = diffs.zipWithIndex.map{ case (expr, index) ⇒ Product(es.updated(index, expr): _*)}
+    Sum(replaced: _*)
+  }
 
   override def subs(v: Var, e: Expr): Expr = Product(es.map(_.subs(v, e)): _*)
 

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -249,6 +249,10 @@ class ExprSpec extends FlatSpec with Matchers {
     t.toString shouldEqual "x * 1 * (x + z) * (x + 3) * z * y"
   }
 
+  it should "compute derivative" in {
+    Product(1, Product('x * 'z * 'x, 3 + 'x), 'y).diff('x).toString shouldEqual "((z * x + x * z) * (3 + x) + x * z * x) * y"
+  }
+
   it should "simplify constants correctly" in {
     // empty sum
     Product().simplify shouldEqual Const(1)

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -200,12 +200,27 @@ class ExprSpec extends FlatSpec with Matchers {
   }
 
   it should "compute derivative" in {
-    val s: Seq[Expr] = Seq(1, Sum('x * 'z *'x, 3 + 'x), 'y)
+    val s: Seq[Expr] = Seq(1, Sum('x * 'z * 'x, 3 + 'x), 'y)
     val z = Sum(s: _*)
     val z_diff_x = z.diff('x)
-    z_diff_x shouldEqual Sum('z * 'x , 'x * 'z , 1)
+    z_diff_x.toString shouldEqual "z * x + x * z + 1"
   }
-  
+
+  it should "simplify constants correctly" in {
+    // empty sum
+    Sum().simplify shouldEqual Const(0)
+    // just one zero
+    Sum(0).simplify shouldEqual Const(0)
+    // only constants yield a Const
+    Sum(0, 1, 2, 0, 0, 0, 3).simplify shouldEqual Const(6)
+
+    // only non-constants
+    Sum('x, 'y, -'x, 'y).simplify shouldEqual Sum('x, 'y, -'x, 'y)
+
+    // both constants and non-constants
+    Sum('x, 1, 2, 'x, 0, 'x, 0, 0, 3).simplify shouldEqual Sum('x, 'x, 'x, 6)
+  }
+
   behavior of "Product"
 
   it should "print all multiplicands" in {

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -248,4 +248,35 @@ class ExprSpec extends FlatSpec with Matchers {
     val t = 'x * z
     t.toString shouldEqual "x * 1 * (x + z) * (x + 3) * z * y"
   }
+
+  it should "simplify constants correctly" in {
+    // empty sum
+    Product().simplify shouldEqual Const(1)
+    // just one zero
+    Product(0).simplify shouldEqual Const(0)
+    Product(1).simplify shouldEqual Const(1)
+    // only constants yield a Const
+    Product(0, 1, 2, 0, 0, 0, 3).simplify shouldEqual Const(0)
+    Product(1, 1, 2, 1, 1, 1, 3).simplify shouldEqual Const(6)
+
+    // only non-constants
+    Product('x, 'y, -'x, 'y).simplify shouldEqual Product('x, 'y, -'x, 'y)
+
+    // both constants and non-constants
+    Product('x, 1, 2, 'x, 0, 'x, 1, 1, 3).simplify shouldEqual Const(0)
+    Product('x, 1, 2, 'x, 1, 'x, 1, 1, 3).simplify shouldEqual Product('x, 'x, 'x, 6)
+  }
+
+  it should "convert to int" in {
+    Product(1, 2, 1, 1, 1, 1, 3).toInt shouldEqual 6
+
+    the[Exception] thrownBy {
+      Product(0, 1, 2, 0, 'z, 0, 'x, 3).toInt shouldEqual 6
+    } should have message "Cannot evaluate toInt for an expression containing a variable z."
+  }
+
+  it should "substitute everywhere" in {
+    Product('x, 1, 'x, 2).subs('x, 'z) shouldEqual Product('z, 1, 'z, 2)
+  }
+
 }

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -221,6 +221,18 @@ class ExprSpec extends FlatSpec with Matchers {
     Sum('x, 1, 2, 'x, 0, 'x, 0, 0, 3).simplify shouldEqual Sum('x, 'x, 'x, 6)
   }
 
+  it should "convert to int" in {
+    Sum(0, 1, 2, 0, 0, 0, 3).toInt shouldEqual 6
+
+    the[Exception] thrownBy {
+      Sum(0, 1, 2, 0, 'z, 0, 'x, 3).toInt shouldEqual 6
+    } should have message "Cannot evaluate toInt for an expression containing a variable z."
+  }
+
+  it should "substitute everywhere" in {
+    Sum('x, 1, 'x, 2).subs('x, 'z) shouldEqual Sum('z, 1, 'z, 2)
+  }
+
   behavior of "Product"
 
   it should "print all multiplicands" in {


### PR DESCRIPTION
`Sum()` and `Product()` represent flat multi-term expressions `x+y+z+...` and `a*b*c*...`

* [x] Implement all operations for `Sum` and `Product`
* [ ] implement `expand` with flattening, so that `Sum(Add(), Sum(), Add())` etc. are transformed into a single-level `Sum()` of `Product()` terms.