### PR TITLE
removed ADD SUBTRACT and MULTIPLY

### DIFF
--- a/src/main/scala/com/github/symcal/Expr.scala
+++ b/src/main/scala/com/github/symcal/Expr.scala
@@ -3,16 +3,31 @@ package com.github.symcal
 import scala.language.implicitConversions
 
 sealed trait Expr {
-  def +(x: Expr): Add = Add(this, x)
+  def +(x: Expr): Sum = (this, x) match {
+    case (Sum(y@_*), Sum(z@_*)) => Sum(y ++ z: _*)
+    case (Sum(y@_*), _) => Sum(y :+ x: _*)
+    case (_, Sum(z@_*)) => Sum(Seq(this) ++ z: _*)
+    case (_, _) => Sum(this, x)
+  }
 
-  def -(x: Expr): Subtract = Subtract(this, x)
+  def -(x: Expr): Sum = (this, x) match {
+    case (Sum(y@_*), Sum(z@_*)) => Sum(y ++ z.map(-_): _*)
+    case (Sum(y@_*), _) => Sum(y :+ -x: _*)
+    case (_, Sum(z@_*)) => Sum(Seq(this) ++ z.map(-_): _*)
+    case (_, _) => Sum(this, -x)
+  }
 
   def unary_- : Expr = this match {
     case Minus(x) ⇒ x
     case y ⇒ Minus(y)
   }
 
-  def *(x: Expr): Multiply = Multiply(this, x)
+  def *(x: Expr): Product = (this, x) match {
+    case (Product(y@_*), Product(z@_*)) => Product(y ++ z: _*)
+    case (Product(y@_*), _) => Product(y :+ x: _*)
+    case (_, Product(z@_*)) => Product(Seq(this) ++ z: _*)
+    case (_, _) => Product(this, x)
+  }
 
   // The '#' character is needed for precedence
   def #^(d: Int): IntPow = IntPow(this, d)
@@ -25,7 +40,9 @@ sealed trait Expr {
 
   def simplify: Expr
 
-  def subs(v: Var, e: Expr): Expr
+  final def subs(v: Var, e: Expr): Expr = subsInternal(v, e).simplify
+
+  private[symcal] def subsInternal(v: Var, e: Expr): Expr
 
   final private[symcal] def stringForm(level: Int): String =
     if (precedenceLevel < level)
@@ -63,13 +80,10 @@ object Expr {
   final val precedenceOfConst = 100
 
   def freeVars(e: Expr): Set[Var] = e match {
-    case Const(value) ⇒ Set()
-    case Subtract(x, y) ⇒ freeVars(x) ++ freeVars(y)
+    case Const(_) ⇒ Set()
     case Minus(x) ⇒ freeVars(x)
-    case Add(x, y) ⇒ freeVars(x) ++ freeVars(y)
-    case Multiply(x, y) ⇒ freeVars(x) ++ freeVars(y)
     case Var(name) ⇒ Set(Var(name))
-    case IntPow(x, d) ⇒ freeVars(x)
+    case IntPow(x, _) ⇒ freeVars(x)
     case Sum(es@_*) ⇒ es.flatMap(freeVars).toSet
     case Product(es@_*) ⇒ es.flatMap(freeVars).toSet
   }
@@ -130,7 +144,7 @@ final case class Const(value: Int) extends Expr {
 
   private[symcal] def diffInternal(x: Var): Expr = Const(0)
 
-  override def subs(v: Var, e: Expr): Expr = this
+  override def subsInternal(v: Var, e: Expr): Expr = this
 
   override def precedenceLevel: Int = Expr.precedenceOfConst
 
@@ -143,37 +157,12 @@ final case class Const(value: Int) extends Expr {
   override def expandInternal: Sum = Sum(this)
 }
 
-final case class Subtract(x: Expr, y: Expr) extends Expr {
-  override def toInt: Int = x.toInt - y.toInt
-
-  private[symcal] def diffInternal(z: Var): Expr = x.diff(z) - y.diff(z)
-
-  override def subs(v: Var, e: Expr): Expr = (x.subs(v, e) - y.subs(v, e)).simplify
-
-  override def precedenceLevel: Int = Expr.precedenceOfSubtract
-
-  override def simplify: Expr = (x.simplify, y.simplify) match {
-    case (Const(0), ys) ⇒ Minus(ys).simplify
-    case (xs, Const(0)) ⇒ xs
-    case (Const(a), Const(b)) ⇒ Const(a - b)
-    case (xs, ys) ⇒ xs - ys
-  }
-
-  override protected def printInternal: String = x.stringForm(Expr.precedenceOfAdd) + " - " + y.stringForm(Expr.precedenceOfMultiply)
-
-  /** The result of `expand` is always a [[Sum]] that contains no nested [[Sum]]s.
-    *
-    * @return Equivalent expression with flattened structure, expanding all parentheses.
-    */
-  override def expandInternal: Sum = Sum(x.expandInternal.es ++ y.expandInternal.es.map(-_): _*)
-}
-
 final case class Minus(x: Expr) extends Expr {
   override def toInt: Int = -x.toInt
 
   private[symcal] def diffInternal(z: Var): Expr = -x.diff(z)
 
-  override def subs(v: Var, e: Expr): Expr = (-x.subs(v, e)).simplify
+  override def subsInternal(v: Var, e: Expr): Expr = (-x.subsInternal(v, e)).simplify
 
   override def precedenceLevel: Int = Expr.precedenceOfMinus
 
@@ -188,69 +177,13 @@ final case class Minus(x: Expr) extends Expr {
   override def expandInternal: Sum = Sum(x.expandInternal.es.map(-_): _*)
 }
 
-final case class Add(x: Expr, y: Expr) extends Expr {
-  override def toInt: Int = x.toInt + y.toInt
-
-  private[symcal] def diffInternal(z: Var): Expr = x.diff(z) + y.diff(z)
-
-  override def simplify: Expr = (x.simplify, y.simplify) match {
-    case (Const(0), ys) => ys
-    case (xs, Const(0)) => xs
-    case (Const(a), Const(b)) => Const(a + b)
-    case (xs, ys) => xs + ys
-  }
-
-  override def subs(v: Var, e: Expr): Expr = (x.subs(v, e) + y.subs(v, e)).simplify
-
-  override def printInternal: String = {
-    val rest = y match {
-      case Minus(yy) ⇒ " - " + yy.stringForm(Expr.precedenceOfMultiply)
-      case _ ⇒ " + " + y.stringForm(precedenceLevel)
-    }
-    x.stringForm(precedenceLevel) + rest
-  }
-
-  override def precedenceLevel: Int = Expr.precedenceOfAdd
-
-  override def expandInternal: Sum = Sum(x.expandInternal.es ++ y.expandInternal.es: _*)
-}
-
-final case class Multiply(x: Expr, y: Expr) extends Expr {
-  override def toInt: Int = x.toInt * y.toInt
-
-  private[symcal] def diffInternal(z: Var): Expr = Multiply(x.diff(z), y) + Multiply(x, y.diff(z))
-
-  override def simplify: Expr = (x.simplify, y.simplify) match {
-    case (Const(1), ys) => ys
-    case (xs, Const(1)) => xs
-    case (Const(0), _) => Const(0)
-    case (_, Const(0)) => Const(0)
-    case (Const(a), Const(b)) => Const(a * b)
-    case (xs, ys) => xs * ys
-  }
-
-  override def subs(v: Var, e: Expr): Expr = (x.subs(v, e) * y.subs(v, e)).simplify
-
-  override def printInternal: String = x.stringForm(precedenceLevel) + " * " + y.stringForm(precedenceLevel)
-
-  override def precedenceLevel: Int = Expr.precedenceOfMultiply
-
-  override def expandInternal: Sum = {
-    val terms = for {
-      xx <- x.expandInternal.es
-      yy <- y.expandInternal.es
-    } yield Product(xx, yy).flatten
-    Sum(terms: _*)
-  }
-}
-
 final case class Var(name: Symbol) extends Expr {
   override def toInt: Int =
     throw new Exception(s"Cannot evaluate toInt for an expression containing a variable ${name.name}.")
 
   private[symcal] def diffInternal(x: Var): Expr = if (name == x.name) Const(1) else Const(0)
 
-  override def subs(v: Var, e: Expr): Expr = v match {
+  override def subsInternal(v: Var, e: Expr): Expr = v match {
     case Var(`name`) ⇒ e
     case _ ⇒ this
   }
@@ -280,7 +213,7 @@ final case class IntPow(x: Expr, d: Const) extends Expr {
     case (xs, _) ⇒ IntPow(xs, d)
   }
 
-  override def subs(v: Var, e: Expr): Expr = IntPow(x.subs(v, e), d).simplify
+  override def subsInternal(v: Var, e: Expr): Expr = IntPow(x.subsInternal(v, e), d).simplify
 
   override def printInternal: String = x.stringForm(precedenceLevel + 1) + "^" + d.print
 
@@ -313,7 +246,7 @@ final case class Sum(es: Expr*) extends Expr {
 
   private[symcal] def diffInternal(x: Var): Expr = Sum(es.map(_.diff(x)): _*)
 
-  override def subs(v: Var, e: Expr): Expr = Sum(es.map(_.subs(v, e)): _*)
+  override def subsInternal(v: Var, e: Expr): Expr = Sum(es.map(_.subsInternal(v, e)): _*)
 
   override def precedenceLevel: Int = Expr.precedenceOfAdd
 
@@ -330,12 +263,11 @@ final case class Sum(es: Expr*) extends Expr {
   override def simplify: Expr = {
     val (const, nonconst) = es.map(_.simplify).partition(_.isConst)
     // mergedConstants is always non-empty but can be Const(0)
-    val mergedConstants = const.foldLeft[Expr](Const(0))((x, y) ⇒ (x + y).simplify)
-    val mergedExprs =
-      mergedConstants match {
-        case Const(0) ⇒ nonconst
-        case _ ⇒ nonconst :+ mergedConstants
-      }
+    val mergedConstants = const.foldLeft[Expr](Const(0))((x, y) ⇒ Const(x.toInt + y.toInt))
+    val mergedExprs = mergedConstants match {
+      case Const(0) ⇒ nonconst
+      case _ ⇒ nonconst :+ mergedConstants
+    }
     // There are three cases now: empty sequence, one expr, and more than one expr.
     mergedExprs.headOption match {
       case Some(e) ⇒
@@ -359,7 +291,7 @@ final case class Product(es: Expr*) extends Expr {
     Sum(replaced: _*)
   }
 
-  override def subs(v: Var, e: Expr): Expr = Product(es.map(_.subs(v, e)): _*)
+  override def subsInternal(v: Var, e: Expr): Expr = Product(es.map(_.subsInternal(v, e)): _*)
 
   override def precedenceLevel: Int = Expr.precedenceOfMultiply
 
@@ -368,7 +300,7 @@ final case class Product(es: Expr*) extends Expr {
   override def simplify: Expr = {
     val (const, nonconst) = es.map(_.simplify).partition(_.isConst)
     // mergedConstants is always non-empty but can be Const(0) or Const(1)
-    val mergedConstants = const.foldLeft[Expr](Const(1))((x, y) ⇒ (x * y).simplify)
+    val mergedConstants = const.foldLeft[Expr](Const(1))((x, y) ⇒ Const(x.toInt * y.toInt))
     val mergedExprs =
       mergedConstants match {
         case Const(0) ⇒ Seq(Const(0))

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -323,6 +323,11 @@ class ExprSpec extends FlatSpec with Matchers {
     ('a * 'a * 'a).expand shouldEqual Product(Var('a), Var('a), Var('a))
   }
 
+  it should "expand nested sums and products" in {
+    ((1 + ('a + 'b) + ('c + 'd)) + 'e).expand shouldEqual 'a + 'b + 'c + 'd + 'e + 1
+    (('a + 'b) * ('a + 'b * 'c * ('d + ('e * 'e + ('f + 'g)) * 'h))).expand shouldEqual 'a * 'a + 'a * 'b * 'c * 'd + 'a * 'b * 'c * 'e * 'e * 'h + 'a * 'b * 'c * 'f * 'h + 'a * 'b * 'c * 'g * 'h + 'b * 'a + 'b * 'b * 'c * 'd + 'b * 'b * 'c * 'e * 'e * 'h + 'b * 'b * 'c * 'f * 'h + 'b * 'b * 'c * 'g * 'h
+  }
+
   behavior of "expand for power"
 
   it should "compute correct multinomial coefficients" in {

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -39,7 +39,7 @@ class ExprSpec extends FlatSpec with Matchers {
     val z = Var('z)
 
     val s = (x + y) * 2 * z
-    s.subs(x, 3).print shouldEqual "(3 + y) * 2 * z"
+    s.subs(x, 3).print shouldEqual "2 * (y + 3) * z"
 
     val t = s.subs(z, 3).diff(y)
     t.toInt shouldEqual 6
@@ -49,7 +49,7 @@ class ExprSpec extends FlatSpec with Matchers {
     (Const(0) + Const(1) + Const(0) + Const(2)).simplify shouldEqual Const(3)
     ((Const(0) * Const(3) + Const(2) * Const(2)) * Const(2)).simplify shouldEqual Const(8)
     (0 + 'x + 1).simplify shouldEqual 'x + 1
-    (1 + 0 + 'x + 1).simplify shouldEqual 1 + 'x + 1
+    (1 + 0 + 'x + 1).simplify shouldEqual 'x + 2
   }
 
   behavior of "derivative"
@@ -91,14 +91,14 @@ class ExprSpec extends FlatSpec with Matchers {
 
   it should "evaluate simple expressions" in {
     val x: Var = 'x
-    // Here, x and 'x are the same variable and should be both substituted at once.
+    // Here, x and 'x are the same variable and should be both subsstituted at once.
     ((x + 1) * ('x + 2)).subs(x, 3).toInt shouldEqual 20
 
     val y: Var = 'y
     val ex1 = ('x + 1) * (2 * x + y)
     val ex2 = ex1.subs(x, 3)
     val ex3 = ex2.subs(y, 4)
-    ex2 shouldEqual 4 * (6 + y)
+    ex2 shouldEqual 4 * (y + 6)
     ex3 shouldEqual Const(40)
   }
 
@@ -141,7 +141,7 @@ class ExprSpec extends FlatSpec with Matchers {
     (-(-'x - 1)).print shouldEqual "-(-x - 1)"
     ('x * (-'y)).print shouldEqual "x * (-y)"
     ('x * ('z - 'y)).print shouldEqual "x * (z - y)"
-    ('x - ('z + 'y)).print shouldEqual "x - (z + y)"
+    ('x - ('z + 'y)).print shouldEqual "x - z - y"
     ('x + ('z - 'y)).print shouldEqual "x + z - y"
     ('x - ('z - 'y)).print shouldEqual "x - (z - y)"
     (('x + 'z) - 'y).print shouldEqual "x + z - y"
@@ -205,7 +205,7 @@ class ExprSpec extends FlatSpec with Matchers {
 
   it should "print minus correctly" in {
     ('a + (-'b)).print shouldEqual "a - b"
-    ('a - (-'b)).print shouldEqual "a - (-b)"
+    ('a - (-'b)).print shouldEqual "a + b"
   }
 
   it should "compute derivative" in {
@@ -230,6 +230,11 @@ class ExprSpec extends FlatSpec with Matchers {
     Sum('x, 1, 2, 'x, 0, 'x, 0, 0, 3).simplify shouldEqual Sum('x, 'x, 'x, 6)
   }
 
+  it should "simplify Sum(Sum(y, z), x))" in {
+    val s = Sum(Sum('y, 'z), 'x)
+    s.simplify shouldEqual 'y + 'z + 'x
+  }
+
   it should "convert to int" in {
     Sum(0, 1, 2, 0, 0, 0, 3).toInt shouldEqual 6
 
@@ -238,7 +243,7 @@ class ExprSpec extends FlatSpec with Matchers {
     } should have message "Cannot evaluate toInt for an expression containing a variable z."
   }
 
-  it should "substitute everywhere" in {
+  it should "subsstitute everywhere" in {
     Sum('x, 1, 'x, 2).subs('x, 'z) shouldEqual Sum('z, 1, 'z, 2)
   }
 
@@ -288,7 +293,7 @@ class ExprSpec extends FlatSpec with Matchers {
     } should have message "Cannot evaluate toInt for an expression containing a variable z."
   }
 
-  it should "substitute everywhere" in {
+  it should "subsstitute everywhere" in {
     Product('x, 1, 'x, 2).subs('x, 'z) shouldEqual Product('z, 1, 'z, 2)
   }
 

--- a/src/test/scala/com/github/symcal/ExprSpec.scala
+++ b/src/test/scala/com/github/symcal/ExprSpec.scala
@@ -91,7 +91,7 @@ class ExprSpec extends FlatSpec with Matchers {
 
   it should "evaluate simple expressions" in {
     val x: Var = 'x
-    // Here, x and 'x are the same variable and should be both subsstituted at once.
+    // Here, x and 'x are the same variable and should be both substituted at once.
     ((x + 1) * ('x + 2)).subs(x, 3).toInt shouldEqual 20
 
     val y: Var = 'y
@@ -143,9 +143,10 @@ class ExprSpec extends FlatSpec with Matchers {
     ('x * ('z - 'y)).print shouldEqual "x * (z - y)"
     ('x - ('z + 'y)).print shouldEqual "x - z - y"
     ('x + ('z - 'y)).print shouldEqual "x + z - y"
-    ('x - ('z - 'y)).print shouldEqual "x - (z - y)"
+    ('x - ('z - 'y)).print shouldEqual "x - z + y"
     (('x + 'z) - 'y).print shouldEqual "x + z - y"
     (-('x + 'z) - 'y).print shouldEqual "-(x + z) - y"
+    (-('x + 'z) - 'y).simplify.print shouldEqual "-(x + z) - y"
   }
 
   it should "simplify double minus" in {
@@ -243,8 +244,8 @@ class ExprSpec extends FlatSpec with Matchers {
     } should have message "Cannot evaluate toInt for an expression containing a variable z."
   }
 
-  it should "subsstitute everywhere" in {
-    Sum('x, 1, 'x, 2).subs('x, 'z) shouldEqual Sum('z, 1, 'z, 2)
+  it should "substitute everywhere" in {
+    Sum('x, 1, 'x, 2).subs('x, 'z) shouldEqual Sum('z, 'z, 3)
   }
 
   behavior of "Product"
@@ -264,7 +265,7 @@ class ExprSpec extends FlatSpec with Matchers {
   }
 
   it should "compute derivative" in {
-    Product(1, Product('x * 'z * 'x, 3 + 'x), 'y).diff('x).print shouldEqual "((z * x + x * z) * (3 + x) + x * z * x) * y"
+    Product(1, Product('x * 'z * 'x, 3 + 'x), 'y).diff('x).print shouldEqual "((z * x + x * z) * (x + 3) + x * z * x) * y"
   }
 
   it should "simplify constants correctly" in {
@@ -293,8 +294,8 @@ class ExprSpec extends FlatSpec with Matchers {
     } should have message "Cannot evaluate toInt for an expression containing a variable z."
   }
 
-  it should "subsstitute everywhere" in {
-    Product('x, 1, 'x, 2).subs('x, 'z) shouldEqual Product('z, 1, 'z, 2)
+  it should "substitute everywhere" in {
+    Product('x, 1, 'x, 2).subs('x, 'z) shouldEqual Product(2, 'z, 'z)
   }
 
   behavior of "expand"


### PR DESCRIPTION
Simplify code. There are no more `Add`, `Subtract`, and `Multiply` case classes; `Sum` and `Product` are used instead. Functionality is unchanged.